### PR TITLE
Use hash for mediaVar to not change between runs

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -8,8 +8,8 @@ crypto = require 'crypto'
 defineVisitor = (base, props) ->
   extend Object.create(base), props
 
-genVar = ->
-  "var#{crypto.randomBytes(12).toString('hex')}"
+genVar = (features) ->
+  "var#{crypto.createHash('md5').update(features).digest('hex')}"
 
 renderValue = (node, options) ->
   options = extend {}, options
@@ -305,7 +305,7 @@ treeVisitor = defineVisitor baseVisitor,
     options.visitDeeper = false
     features = renderValue(node.features, unquote: true)
     if /@{/.exec features
-      mediaVar = genVar()
+      mediaVar = genVar(features)
       @p "#{mediaVar} = \"#{toUnquoted(features)}\""
       @p "@media #{mediaVar}"
     else

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ defineVisitor = function(base, props) {
   return extend(Object.create(base), props);
 };
 
-genVar = function() {
-  return "var" + (crypto.randomBytes(12).toString('hex'));
+genVar = function(features) {
+  return "var" + (crypto.createHash('md5').update(features).digest('hex'));
 };
 
 renderValue = function(node, options) {
@@ -389,7 +389,7 @@ treeVisitor = defineVisitor(baseVisitor, {
       unquote: true
     });
     if (/@{/.exec(features)) {
-      mediaVar = genVar();
+      mediaVar = genVar(features);
       this.p("" + mediaVar + " = \"" + (toUnquoted(features)) + "\"");
       this.p("@media " + mediaVar);
     } else {


### PR DESCRIPTION
This fixes the issue that every run will result in a change, which causes conflicts if multiple people make changes to the same file, even without changing the same line.
